### PR TITLE
use abi field in json if abi field is found

### DIFF
--- a/start.js
+++ b/start.js
@@ -258,6 +258,9 @@ function start() {
   }
   var raw = fs.readFileSync(`${name[0]}.json`);
   var abi = JSON.parse(raw);
+  if (abi["abi"]) {
+    abi = abi["abi"]
+  }
 
   const totalFunction = []
   const totalPublicFunction = []


### PR DESCRIPTION
Hardhat json now is in following format:
```
{
  "_format": "hh-sol-artifact-1",
  "contractName": "xxx",
  "sourceName": "contracts/xxx.sol",
  "abi": [ ... ]
}
```

Running the script will gives an error `TypeError: abi.forEach is not a function` because the ABI array is in the ABI field.

This PR modify the script that if the "abi" field is found in the json, it uses the "abi" value. Otherwise, users have to manually change all xxx.json file to delete the fields not related to "abi", which is super inefficient.